### PR TITLE
feat: expose Zotero related items to library note templates

### DIFF
--- a/docs/template-guide.md
+++ b/docs/template-guide.md
@@ -138,6 +138,7 @@ The template context is an object with two top-level keys: `item` and `settings`
 | `item.annotations`           | `AnnotationContext[]`     | Direct child annotations (for standalone attachment items)            |
 | `item.attachmentAnnotations` | `AnnotationContext[]`     | All annotations across all attachments (flattened)                    |
 | `item.notes`                 | `NoteContext[]`           | Child Zotero notes — see below                                        |
+| `item.relatedItems`          | `RelatedItemContext[]`    | Items linked via Zotero's "Related" tab (`dc:relation`) — see below   |
 
 #### `item.attachments[]` — Attachment Children
 
@@ -163,6 +164,22 @@ The template context is an object with two top-level keys: `item` and `settings`
 | `note.tags`         | `Array<{ tag, type? }>` | Tags                             |
 | `note.dateAdded`    | `string`                | ISO timestamp                    |
 | `note.dateModified` | `string`                | ISO timestamp                    |
+
+#### `item.relatedItems[]` — Related Items
+
+Items the current item is linked to via Zotero's **Related** tab (the `dc:relation` predicate). Each entry corresponds to one related item URI; `key` and `libraryID` are always populated by parsing the URI itself, while the remaining fields are only filled in when the related item is present in ZotFlow's local database.
+
+| Variable             | Type                  | Description                                                                                       |
+| -------------------- | --------------------- | ------------------------------------------------------------------------------------------------- |
+| `rel.key`            | `string`              | Zotero item key of the related item                                                               |
+| `rel.libraryID`      | `number`              | Library ID parsed from the relation URI                                                           |
+| `rel.resolved`       | `boolean`             | `true` if the item was found in the local DB, `false` for cross-library / unsynced / missing items |
+| `rel.title`          | `string \| undefined` | Title of the related item (only when `resolved`)                                                  |
+| `rel.itemType`       | `string \| undefined` | Zotero item type (only when `resolved`)                                                           |
+| `rel.citationKey`    | `string \| undefined` | Citation key, e.g. from Better BibTeX (only when `resolved`)                                      |
+| `rel.notePath`       | `string \| undefined` | Vault path of that item's ZotFlow source note (only when `resolved`)                              |
+
+Cross-library or unsynced relations still appear in the list with `resolved: false` so they can be referenced or surfaced as a placeholder. Guard with `{% if rel.title %}` (or `{% if rel.resolved %}`) when you only want fully-known entries.
 
 #### `item.annotations[]` / `attachment.annotations[]` — Annotations
 
@@ -768,6 +785,26 @@ tags:
 {%- endfor -%}
 {%- endif -%}
 ```
+
+### Listing Related Items
+
+```liquid
+{%- if item.relatedItems.size > 0 -%}
+## Related
+
+{% for rel in item.relatedItems -%}
+{% if rel.notePath -%}
+- [[{{ rel.notePath }}|{{ rel.title }}]]
+{%- elsif rel.title -%}
+- {{ rel.title }} (`{{ rel.key }}`)
+{%- else -%}
+- `{{ rel.key }}` *(not synced)*
+{%- endif %}
+{% endfor -%}
+{%- endif -%}
+```
+
+The three branches handle: items with a known source-note path (wikilink), items found locally but without a resolvable path (plain title + key), and unsynced/cross-library items (key only). Drop branches you don't need.
 
 ### Deep-Linking to Attachments
 

--- a/src/types/template-context.ts
+++ b/src/types/template-context.ts
@@ -52,6 +52,27 @@ export interface ItemTemplateContext {
     annotations: AnnotationTemplateContext[];
     attachmentAnnotations: AnnotationTemplateContext[];
     notes: NoteTemplateContext[];
+
+    // Cross-references (Zotero "Related" tab — dc:relation)
+    relatedItems: RelatedItemTemplateContext[];
+}
+
+/** Template rendering context for a Zotero "related" item (dc:relation). */
+export interface RelatedItemTemplateContext {
+    /** Item key (always present — parsed from the URI even if unresolved). */
+    key: string;
+    /** Library ID (always present — parsed from the URI). */
+    libraryID: number;
+    /** True when the related item was found in the local DB. */
+    resolved: boolean;
+    /** Title of the related item. Undefined when unresolved. */
+    title?: string;
+    /** Zotero item type. Undefined when unresolved. */
+    itemType?: string;
+    /** Citation key (e.g. Better BibTeX). Empty string or undefined when unresolved. */
+    citationKey?: string;
+    /** Vault path of that item's ZotFlow source note. Undefined when unresolved. */
+    notePath?: string;
 }
 
 /** Template rendering context for a Zotero attachment. */

--- a/src/worker/services/library-template.ts
+++ b/src/worker/services/library-template.ts
@@ -6,6 +6,7 @@ import type {
     NoteTemplateContext,
     AnnotationTemplateContext,
     AttachmentTemplateContext,
+    RelatedItemTemplateContext,
 } from "types/template-context";
 import type { IParentProxy } from "bridge/types";
 import type {
@@ -106,6 +107,10 @@ const FALLBACK_FOOTNOTE_TEMPLATE = `{%- if item.creators.length > 1 -%}
 {{ item.creators[0].name }} et al. {%- elsif item.creators.length == 1 -%}
  {{ item.creators[0].name }} {%- else -%}
 Unknown Author {%- endif -%}, *{{ item.title }}* ({{ item.date | slice: 0, 4 }}).`;
+
+// Matches http(s)://zotero.org/{users|groups}/<id>/items/<KEY>
+const ZOTERO_URI_RE =
+    /^https?:\/\/zotero\.org\/(?:users|groups)\/(\d+)\/items\/([A-Z0-9]+)$/i;
 
 /** LiquidJS template engine for rendering library (Zotero) item source notes. */
 export class LibraryTemplateService {
@@ -489,6 +494,8 @@ export class LibraryTemplateService {
             ])
             .then((paths) => paths[`${item.libraryID}:${item.key}`] || []);
 
+        const relatedItems = await this.mapToRelatedItems(data);
+
         return {
             key: item.key,
             version: item.version,
@@ -499,6 +506,7 @@ export class LibraryTemplateService {
             annotations,
             attachmentAnnotations,
             attachments,
+            relatedItems,
             itemType: item.itemType,
             title: item.title || "",
             creators: creatorsObj,
@@ -559,6 +567,65 @@ export class LibraryTemplateService {
 
             raw: annotation,
         };
+    }
+
+    private parseRelationUri(
+        uri: string,
+    ): { libraryID: number; key: string } | null {
+        const m = ZOTERO_URI_RE.exec(uri.trim());
+        if (!m) return null;
+        return { libraryID: Number(m[1]), key: m[2]! };
+    }
+
+    private async mapToRelatedItems(
+        data: any,
+    ): Promise<RelatedItemTemplateContext[]> {
+        const rels = data?.relations as
+            | { [k: string]: string | string[] }
+            | undefined;
+        if (!rels) return [];
+
+        const dc = rels["dc:relation"];
+        if (!dc) return [];
+        const uris = Array.isArray(dc) ? dc : [dc];
+
+        const parsed: { libraryID: number; key: string }[] = [];
+        for (const uri of uris) {
+            const p = this.parseRelationUri(uri);
+            if (p) parsed.push(p);
+        }
+        if (parsed.length === 0) return [];
+
+        const fetched = await db.items.bulkGet(
+            parsed.map((p) => [p.libraryID, p.key]),
+        );
+
+        const out: RelatedItemTemplateContext[] = [];
+        for (let i = 0; i < parsed.length; i++) {
+            const { libraryID, key } = parsed[i]!;
+            const hit = fetched[i];
+            if (!hit) {
+                out.push({ key, libraryID, resolved: false });
+                continue;
+            }
+            let notePath: string | undefined;
+            try {
+                notePath =
+                    await this.notePathService.resolveLibraryNotePath(hit);
+            } catch {
+                notePath = undefined;
+            }
+            out.push({
+                key,
+                libraryID,
+                resolved: true,
+                title: hit.title || "",
+                itemType: hit.itemType,
+                citationKey: hit.citationKey || "",
+                notePath,
+            });
+        }
+        return out;
     }
 
     private async mapToAttachmentContext(


### PR DESCRIPTION
## Summary

- Adds `item.relatedItems` to the library source-note template context, exposing items linked via Zotero's **Related** tab (`dc:relation`).
- Each entry resolves the URI against the local Dexie DB to surface `title`, `itemType`, `citationKey`, and the vault `notePath` of that related item's ZotFlow source note (via the existing `NotePathService`).
- Cross-library / unsynced URIs are kept as entries with `resolved: false` and only `key` + `libraryID` populated, so templates can render them as placeholders.
- Documents the new field in `docs/template-guide.md`: variables table row, new `#### item.relatedItems[]` subsection, and a Tips example with three render branches (wikilink / title fallback / unsynced placeholder).
- Default built-in template intentionally unchanged so existing users' rendered output stays stable; opt-in via custom template.

## Test plan

- [ ] `npm run build:plugin` succeeds (typecheck passes after the new interface).
- [ ] In Zotero, link two items in the same library via the Related tab, sync ZotFlow, and add the `item.relatedItems` example block from the Tips section to the library source-note template — confirm the related item renders as a working wikilink to its source note.
- [ ] Verify the preview path: open the template preview in the Activity Center for a linked item and confirm related items appear (the preview reuses the same `mapToItemContext`).
- [ ] Add a relation pointing to an item in a library you don't sync; confirm the entry appears with `resolved: false` and falls through to the `*(not synced)*` branch of the example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)